### PR TITLE
Version 1.9: Schema fixed

### DIFF
--- a/portable_spreadsheet/__init__.py
+++ b/portable_spreadsheet/__init__.py
@@ -5,5 +5,5 @@ from .cell_slice import CellSlice  # noqa
 from .grammars import GRAMMARS  # noqa
 from .grammar_utils import GrammarUtils  # noqa
 
-__version__ = "0.1.6"
+__version__ = "0.1.9"
 __status__ = "Production"

--- a/portable_spreadsheet/serialization.py
+++ b/portable_spreadsheet/serialization.py
@@ -553,13 +553,12 @@ class Serialization(abc.ABC):
         """
         false = False
         schema = {
-            "$id": "http://portable-spreadsheet.com/spreadsheet.v1.schema.json",  # noqa
+            "$id": "http://portable-spreadsheet.com/spreadsheet.v2.schema.json",  # noqa
             "$schema": "http://json-schema.org/draft-07/schema#",
             "title": "Portable Spreadsheet JSON output schema",
             "description": "JSON schema of the Portable Spreadsheet output",
 
             "required": ["table"],
-            "type": "object",
 
             "properties": {
                 "table": {
@@ -609,7 +608,8 @@ class Serialization(abc.ABC):
                         },
                         "data": {
                             "type": "object",
-                            "required": ["rows"],
+                            "minProperties": 1,
+                            "maxProperties": 1,
                             "properties": {
                                 "^[rows,columns]$": {
                                     "type": "object",
@@ -656,7 +656,8 @@ class Serialization(abc.ABC):
                                                 },
                                                 "^[row_description,column_description]$": {"type": "string"}  # noqa
                                             },
-                                            "required": ["columns"],
+                                            "minProperties": 1,
+                                            "maxProperties": 1,
                                             "additionalProperties": false
                                         }
                                     },

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="portable-spreadsheet",
-    version="0.1.8",
+    version="0.1.9",
     author="David Salac",
     author_email="info@davidsalac.eu",
     description="Simple spreadsheet that keeps tracks of each operation in "


### PR DESCRIPTION
Bug-fix in the JSON schema:

1. Type of the body is not object (bug).
2. Column first did not work (bug).
3. Most famous Python validator `jsonschema` could not parse schema (bug).

All is fixed now.